### PR TITLE
Updated session.cc to contain new callback in libspotify 12.1.103

### DIFF
--- a/src/session.cc
+++ b/src/session.cc
@@ -252,6 +252,13 @@ static void call_connectionstate_updated_callback(sp_session* session) {
 }
 
 /**
+ * spotify callback for the connectionstate_updated event.
+ * See https://developer.spotify.com/technologies/libspotify/docs/12.1.45/structsp__session__callbacks.html
+ */
+static void call_unaccepted_licenses_updated_callback(sp_session* session) {
+}
+
+/**
  * spotify callback for the scrobble_error event.
  * See https://developer.spotify.com/technologies/libspotify/docs/12.1.45/structsp__session__callbacks.html
  */
@@ -285,6 +292,7 @@ static sp_session_callbacks spcallbacks = {
     &call_offline_error_callback,
     &call_credentials_blob_updated_callback,
     &call_connectionstate_updated_callback,
+    &call_unaccepted_licenses_updated_callback,
     &call_scrobble_error_callback,
     &call_private_session_mode_changed_callback
 };


### PR DESCRIPTION
libspotify 12.1.103 added a callback to session, unaccepted_licenses_updated. It needs to be inside session.cc inorder for it to compile
