### PR TITLE
sp_album_cover implemented

### DIFF
--- a/lib/Album.js
+++ b/lib/Album.js
@@ -42,5 +42,33 @@ Album.prototype.toString = function toString() {
     return this.name;
 };
 
+/**
+ * Loads the cover image of this album. After the async fetch over the
+ * libspotify finished, onImageLoaded callback gets executed.
+ */
+Album.prototype.coverImage = function coverImage(onImageLoaded, imageSize) {
+    var size = imageSize || this.CoverImageSize.NORMAL;
+
+    b.album_cover(
+        this.getSession()._sp_session
+        , this._sp_object
+        , onImageLoaded
+        , size
+    );
+};
+
+Album.prototype.smallCoverImage = function smallCoverImage(onImageLoaded) {
+    this.coverImage(onImageLoaded, this.CoverImageSize.SMALL);
+}
+
+Album.prototype.largeCoverImage = function smallCoverImage(onImageLoaded) {
+    this.coverImage(onImageLoaded, this.CoverImageSize.LARGE);
+}
+
+Album.prototype.CoverImageSize = {
+    NORMAL: 0
+    , SMALL: 1
+    , LARGE: 2
+};
 
 module.exports = Album;

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "url": "https://github.com/Floby/node-libspotify.git"
   },
   "engines": {
-    "node": "~0.8.0"
+    "node": ">0.10.0"
   },
   "dependencies": {
-    "bindings": "~1.1.0",
+    "bindings": "~1.1.1",
     "i": "~0.3",
     "format": "0.1",
     "backoff": "~2.0"

--- a/src/album.cc
+++ b/src/album.cc
@@ -131,6 +131,75 @@ static Handle<Value> Album_Artist(const Arguments& args) {
     return scope.Close(artist->object);
 }
 
+/**
+ * Callback for sp_image_add_load_callback in Album_Cover().
+ * It calls the passed JS function callback and passes the raw image data as
+ * parameter as soon as the regarding image loading process has finished.
+ */
+void cb_image_loaded_album(sp_image *image, void *userdata) {
+    Persistent<Function> callback = static_cast<Function*>(userdata);
+    size_t image_size;
+    const void *image_data = sp_image_data(image, &image_size);
+
+    // Create a C++ world slow buffer:
+    node::Buffer *slowBuffer= node::Buffer::New(image_size);
+    memcpy(node::Buffer::Data(slowBuffer), image_data, image_size);
+
+    // Get the Buffer constructor from the JavaScript world:
+    Local<Object> globalObj = Context::GetCurrent()->Global();
+    Local<Function> bufferConstructor = Local<Function>::Cast(globalObj->Get(String::New("Buffer")));
+    Handle<Value> constructorArgs[3] = { slowBuffer->handle_, Integer::New(image_size), Integer::New(0) };
+
+    // Create a JavaScript buffer using the slow buffer:
+    Local<Object> actualBuffer = bufferConstructor->NewInstance(3, constructorArgs);
+
+    // Pass everything to the JavaScript callback:
+    const unsigned argc = 1;
+    Local<Value> argv[argc] = { actualBuffer };
+    callback->Call(callback, argc, argv);
+
+    // Clean up:
+    callback.Dispose();
+    sp_image_release(image);
+}
+
+/**
+ * JS album_cover implementation. Gets the albums image
+ */
+static Handle<Value> Album_Cover(const Arguments& args) {
+    HandleScope scope;
+
+    // test arguments sanity
+    assert(args.Length() == 4);
+    assert(args[0]->IsObject());  // sp_session
+    assert(args[1]->IsObject());  // sp_album
+    assert(args[2]->IsFunction()); // callback after cover image was loaded
+    assert(args[3]->IsNumber());  // sp_image_size
+
+    ObjectHandle<sp_session> *session = ObjectHandle<sp_session>::Unwrap(args[0]);
+    ObjectHandle<sp_album> *album = ObjectHandle<sp_album>::Unwrap(args[1]);
+    Handle<Function> callback = Persistent<Function>::New(Handle<Function>::Cast(args[2]));
+    Handle<Integer> requestedImageSize = Local<Integer>::Cast(args[3]);
+
+    sp_image_size imageSize = SP_IMAGE_SIZE_NORMAL;
+    switch(requestedImageSize->Value()) {
+        case 1:
+            imageSize = SP_IMAGE_SIZE_SMALL;
+            break;
+        case 2:
+            imageSize = SP_IMAGE_SIZE_LARGE;
+            break;
+    }
+
+    const byte *imageId = sp_album_cover(album->pointer, imageSize);
+
+    if(imageId) {
+        sp_image *image = sp_image_create(session->pointer, imageId);
+        sp_image_add_load_callback(image, &cb_image_loaded_album, *callback);
+    }
+
+    return scope.Close(Undefined());
+}
 
 void nsp::init_album(Handle<Object> target) {
     NODE_SET_METHOD(target, "album_is_loaded", Album_Is_Loaded);
@@ -138,5 +207,6 @@ void nsp::init_album(Handle<Object> target) {
     NODE_SET_METHOD(target, "album_year", Album_Year);
     NODE_SET_METHOD(target, "album_type", Album_Type);
     NODE_SET_METHOD(target, "album_artist", Album_Artist);
+    NODE_SET_METHOD(target, "album_cover", Album_Cover);
 }
 

--- a/test/test-031-album.js
+++ b/test/test-031-album.js
@@ -25,5 +25,44 @@ exports.album = {
 
             return test.done();
         });
+    },
+    'cover image - normal size': function(test) {
+        var search = new sp.Search('artist:"Guillemots" track:"Fleet"');
+        search.execute(function() {
+            test.ok(search.tracks.length > 0, "the search should return at least one result");
+            var first = search.tracks[0];
+            var album = first.album;
+
+            album.coverImage(function(buffer) {
+                test.ok(buffer.length > 0);
+                return test.done();
+            });
+        });
+    },
+    'cover image - small size': function(test) {
+        var search = new sp.Search('artist:"Guillemots" track:"Fleet"');
+        search.execute(function() {
+            test.ok(search.tracks.length > 0, "the search should return at least one result");
+            var first = search.tracks[0];
+            var album = first.album;
+
+            album.smallCoverImage(function(buffer) {
+                test.ok(buffer.length > 0);
+                return test.done();
+            });
+        });
+    },
+    'cover image - large size': function(test) {
+        var search = new sp.Search('artist:"Guillemots" track:"Fleet"');
+        search.execute(function() {
+            test.ok(search.tracks.length > 0, "the search should return at least one result");
+            var first = search.tracks[0];
+            var album = first.album;
+
+            album.largeCoverImage(function(buffer) {
+                test.ok(buffer.length > 0);
+                return test.done();
+            });
+        });
     }
 };


### PR DESCRIPTION
hi florent
following pull request contains the implementation of `sp_album_cover` for the album object.

it adds the following methods to the album object:
- `coverImage(cb)`
- `smallCoverImage(cb)`
- `largeCoverImage(cb)`

each of them expects a function callback which will be called as soon as the cover image is loaded. the images raw data will be contained in the first function argument, represented inside a `Buffer`:

```
album.coverImage(function(buffer) {
    if(buffer.length > 0) {
        fs.writeFileSync('cover.jpg', buffer);
    } else {
        console.log('image was not available');
    }
});
```

a unit test is included and should run successfully. further i allowed myself to update your package.json with the minimum requirement of node.js 0.10.0 since `node-libspotify` needs the new stream implementations.

please let me know if you want some modifications/improvements on the code. otherwise i'd be happy if you can use my addition to bring node-libspotify one step closer to completion.

cheers,
manu
